### PR TITLE
Update MessageCommandsModule.cs

### DIFF
--- a/src/Quotebot/Interactions/MessageCommandsModule.cs
+++ b/src/Quotebot/Interactions/MessageCommandsModule.cs
@@ -57,7 +57,7 @@ namespace Quotebot.Interactions
            var respsonse = countedQuotes switch
            {
                0 => $"{guildUser.Nickname ?? guildUser.Username} has never been quoted.",
-               1 => $"{guildUser.Nickname ?? guildUser.Username} has been quoted {countedQuotes} once.",
+               1 => $"{guildUser.Nickname ?? guildUser.Username} has been quoted once.",
                _ => $"{guildUser.Nickname ?? guildUser.Username} has been quoted {countedQuotes} times."
            };
 


### PR DESCRIPTION
fixed output text when a user was only quoted once.