### PR TITLE
Feature/fix scaleapp versions issue

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Generate Version
         shell: pwsh
         run: |
-          $version = "1.0.$([System.DateTime]::Now.ToString('yyMM')).$([System.DateTime]::Now.ToString('dd'))$($Env:GITHUB_RUN_NUMBER)$($Env:GITHUB_RUN_ATTEMPT)"
+          $version = "1.$([System.DateTime]::Now.ToString('yyMM')).$([System.DateTime]::Now.ToString('dd'))$($Env:GITHUB_RUN_NUMBER).$($Env:GITHUB_RUN_ATTEMPT)"
           echo "BUILD_VERSION=$version" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           Write-Host $version
 

--- a/src/Quotebot/Commands/QuoteCommandModule.cs
+++ b/src/Quotebot/Commands/QuoteCommandModule.cs
@@ -35,7 +35,9 @@ public class QuoteCommandModule : ModuleBase<SocketCommandContext>
     [Summary("Gets the bot's current version")]
     public async Task SayVersion()
     {
-        await ReplyAsync($"My current version is {Assembly.GetEntryAssembly()?.GetName().Version}");
+        Version version = Assembly.GetEntryAssembly()?.GetName().Version ??
+                          throw new Exception("Unable to determine entry assembly");
+        await ReplyAsync($"Version: `{version.Major}.{version.Minor}.{version.Build}.{version.Revision:00000}`");
     }
 
     [Command("find")]

--- a/src/Quotebot/Commands/QuoteCommandModule.cs
+++ b/src/Quotebot/Commands/QuoteCommandModule.cs
@@ -37,7 +37,7 @@ public class QuoteCommandModule : ModuleBase<SocketCommandContext>
     {
         Version version = Assembly.GetEntryAssembly()?.GetName().Version ??
                           throw new Exception("Unable to determine entry assembly");
-        await ReplyAsync($"Version: `{version.Major}.{version.Minor}.{version.Build}.{version.Revision:00000}`");
+        await ReplyAsync($"Version: `{version.Major}.{version.Minor}.{version.Build:000#}.{version.Revision}`");
     }
 
     [Command("find")]


### PR DESCRIPTION
`!quote version` will output the incorrect version if the Day of Month is a single digit. Which means if you copy pasted that into the `ScaleApp` workflow it won't work because the actual version of the app would be `05` not `5`. e.g. `1.0.2102.5152` is incorrect and in reality is `1.0.2102.05152`. 

The PR also adjusts the version format to now be `MAJOR.YYMM.DDGITHUB_RUN_NUMBER.GITHUB_RUN_ATTEMPT` to prevent an unsigned short integer overflow. 